### PR TITLE
Double click breaks dragging and tripple click on Mac

### DIFF
--- a/src/lib/platform/OSXScreen.h
+++ b/src/lib/platform/OSXScreen.h
@@ -335,8 +335,8 @@ private:
 	CFRunLoopSourceRef		m_eventTapRLSR;
 
 	// for double click coalescing.
-	double					m_lastSingleClick;
-	double					m_lastDoubleClick;
+	double					m_lastClickTime;
+    int                     m_clickState;
 	SInt32					m_lastSingleClickXCursor;
 	SInt32					m_lastSingleClickYCursor;
 


### PR DESCRIPTION
This patch corrects issues with double click and adds triple click to
MacOSX. Double click was functioning but double clicking and then
dragging would not work.

Triple clicking now selects an entire line and double clicking and dragging now adds words to the selection correctly.

Fixes Bug: 3784