### PR TITLE
Fix for ISO C++ ambiguous call on some archs

### DIFF
--- a/src/lib/ipc/IpcClientProxy.cpp
+++ b/src/lib/ipc/IpcClientProxy.cpp
@@ -146,7 +146,7 @@ IpcClientProxy::send(const IpcMessage& message)
 	switch (message.type()) {
 	case kIpcLogLine: {
 		const IpcLogLineMessage& llm = static_cast<const IpcLogLineMessage&>(message);
-		String logLine = llm.logLine();
+		const String logLine = llm.logLine();
 		ProtocolUtil::writef(&m_stream, kIpcMsgLogLine, &logLine);
 		break;
 	}

--- a/src/lib/ipc/IpcServerProxy.cpp
+++ b/src/lib/ipc/IpcServerProxy.cpp
@@ -94,7 +94,7 @@ IpcServerProxy::send(const IpcMessage& message)
 
 	case kIpcCommand: {
 		const IpcCommandMessage& cm = static_cast<const IpcCommandMessage&>(message);
-		String command = cm.command();
+		const String command = cm.command();
 		ProtocolUtil::writef(&m_stream, kIpcMsgCommand, &command);
 		break;
 	}

--- a/src/lib/server/ClientProxy1_4.cpp
+++ b/src/lib/server/ClientProxy1_4.cpp
@@ -80,7 +80,7 @@ ClientProxy1_4::cryptoIv()
 
 	byte iv[CRYPTO_IV_SIZE];
 	cryptoStream->newIv(iv);
-	String data(reinterpret_cast<const char*>(iv), CRYPTO_IV_SIZE);
+	const String data(reinterpret_cast<const char*>(iv), CRYPTO_IV_SIZE);
 
 	LOG((CLOG_DEBUG2 "send crypto iv change to \"%s\"", getName().c_str()));
 	ProtocolUtil::writef(getStream(), kMsgDCryptoIv, &data);


### PR DESCRIPTION
Had some problems compiling for Sparc/Linux (yeah, widely used combo, I know), this seemed to fix it.  Idk why this is only affecting my sparc machine (gcc 4.8, same as my x86_64 box)