### PR TITLE
Changed server shortcut on GUI main window

### DIFF
--- a/src/gui/res/MainWindowBase.ui
+++ b/src/gui/res/MainWindowBase.ui
@@ -87,7 +87,7 @@
        </sizepolicy>
       </property>
       <property name="title">
-       <string>&amp;Server (share this computer's mouse and keyboard):</string>
+       <string>Ser&amp;ver (share this computer's mouse and keyboard):</string>
       </property>
       <property name="checkable">
        <bool>true</bool>


### PR DESCRIPTION
The shortcut for the server checkbox on the main gui is now Alt-V. This deconflicts the start/stop button.
Fixes #4367