### PR TITLE
Attempt to fix issue with \ and | on win8 client

### DIFF
--- a/src/lib/platform/MSWindowsKeyState.cpp
+++ b/src/lib/platform/MSWindowsKeyState.cpp
@@ -132,7 +132,7 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x059 */ { kKeyNone },		// VK_Y
 	/* 0x05a */ { kKeyNone },		// VK_Z
 	/* 0x05b */ { kKeySuper_L },	// VK_LWIN
-	/* 0x05c */ { kKeySuper_R },	// VK_RWIN
+	/* 0x05c */ { kKeyNone },	// VK_RWIN
 	/* 0x05d */ { kKeyMenu },		// VK_APPS
 	/* 0x05e */ { kKeyNone },		// undefined
 	/* 0x05f */ { kKeySleep },		// VK_SLEEP
@@ -164,7 +164,7 @@ const KeyID				MSWindowsKeyState::s_virtualKey[] =
 	/* 0x079 */ { kKeyF10 },		// VK_F10
 	/* 0x07a */ { kKeyF11 },		// VK_F11
 	/* 0x07b */ { kKeyF12 },		// VK_F12
-	/* 0x07c */ { kKeyF13 },		// VK_F13
+	/* 0x07c */ { kKeyNone },		// VK_F13
 	/* 0x07d */ { kKeyF14 },		// VK_F14
 	/* 0x07e */ { kKeyF15 },		// VK_F15
 	/* 0x07f */ { kKeyF16 },		// VK_F16


### PR DESCRIPTION
This has not been tested as I do not have a windows build environment but I think it might work.  Pressing the backslash or bar key results in ctrl and alt keypresses on the client.  This stops it displaying the correct character in certain apps, e.g. cygwin, virtual box, rdp.  Please could you make a win8 binary available for me to test out the changes?