### PR TITLE
Modifier keys often stuck down on Mac client

### DIFF
--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -189,7 +189,7 @@ OSXKeyState::OSXKeyState(IEventQueue* events) :
 OSXKeyState::OSXKeyState(IEventQueue* events, synergy::KeyMap& keyMap) :
 	KeyState(events, keyMap)
 {
-	init();
+	init();a
 }
 
 OSXKeyState::~OSXKeyState()
@@ -388,6 +388,34 @@ OSXKeyState::fakeCtrlAltDel()
 {
 	// pass keys through unchanged
 	return false;
+}
+
+CGEventFlags
+OSXKeyState::getModifierStateAsOSXFlags()
+{
+    CGEventFlags modifiers = 0;
+    
+    if (m_shiftPressed) {
+        modifiers |= kCGEventFlagMaskShift;
+    }
+    
+    if (m_controlPressed) {
+        modifiers |= kCGEventFlagMaskControl;
+    }
+    
+    if (m_altPressed) {
+        modifiers |= kCGEventFlagMaskAlternate;
+    }
+    
+    if (m_superPressed) {
+        modifiers |= kCGEventFlagMaskCommand;
+    }
+    
+    if (m_capsPressed) {
+        modifiers |= kCGEventFlagMaskAlphaShift;
+    }
+    
+    return modifiers;
 }
 
 KeyModifierMask

--- a/src/lib/platform/OSXKeyState.cpp
+++ b/src/lib/platform/OSXKeyState.cpp
@@ -189,7 +189,7 @@ OSXKeyState::OSXKeyState(IEventQueue* events) :
 OSXKeyState::OSXKeyState(IEventQueue* events, synergy::KeyMap& keyMap) :
 	KeyState(events, keyMap)
 {
-	init();a
+	init();
 }
 
 OSXKeyState::~OSXKeyState()

--- a/src/lib/platform/OSXKeyState.h
+++ b/src/lib/platform/OSXKeyState.h
@@ -100,6 +100,7 @@ public:
 	virtual SInt32		pollActiveGroup() const;
 	virtual void		pollPressedKeys(KeyButtonSet& pressedKeys) const;
 
+    CGEventFlags getModifierStateAsOSXFlags();
 protected:
 	// KeyState overrides
 	virtual void		getKeyMap(synergy::KeyMap& keyMap);

--- a/src/lib/platform/OSXScreen.cpp
+++ b/src/lib/platform/OSXScreen.cpp
@@ -528,6 +528,10 @@ OSXScreen::postMouseEvent(CGPoint& pos) const
     // Dragging events also need the click state
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
     
+    // Fix for sticky keys
+    CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
+    CGEventSetFlags(event, modifiers);
+    
 	CGEventPost(kCGHIDEventTap, event);
 	
 	CFRelease(event);
@@ -594,6 +598,10 @@ OSXScreen::fakeMouseButton(ButtonID id, bool press)
     CGEventRef event = CGEventCreateMouseEvent(NULL, type, pos, index);
     
     CGEventSetIntegerValueField(event, kCGMouseEventClickState, m_clickState);
+    
+    // Fix for sticky keys
+    CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
+    CGEventSetFlags(event, modifiers);
     
     m_buttonState.set(index, state);
     CGEventPost(kCGHIDEventTap, event);
@@ -705,6 +713,10 @@ OSXScreen::fakeMouseWheel(SInt32 xDelta, SInt32 yDelta) const
 			mapScrollWheelFromSynergy(yDelta),
 			-mapScrollWheelFromSynergy(xDelta));
 		
+        // Fix for sticky keys
+        CGEventFlags modifiers = m_keyState->getModifierStateAsOSXFlags();
+        CGEventSetFlags(scrollEvent, modifiers);
+        
 		CGEventPost(kCGHIDEventTap, scrollEvent);
 		CFRelease(scrollEvent);
 #else


### PR DESCRIPTION
On MacOSX modifier keys will often stick. I was able to verify that modifier state in the Synergy client is correct and the system modifier state is incorrect. Furthermore, I was able to verify that an event is posted to the operating system for the key up event. 

After determining that Synergy is in the correct state, I attempted to fix this issue by asking the operating system what its modifier state was before every event was sent and then sending extra events to correct the systems modifier state if it was incorrect. This solution worked but after looking at the log of corrections, it became evident that this code was only required to correct mouse events. This was due to the fact that all key events pass the modifier state along with them. So the final solution was to remove the consistency check and add the modifier state to all mouse events.

This seems like an odd fix, but I have been unable to cause keys stick after these changes. 

Steps to cause a modifier key stick before these changes:
1. Hold down a modifier key (Shift key, etc)
2. Move mouse as rapidly as possible without stopping
3. While continuing to move the mouse rapidly, release the modifier key
4. Continue moving the mouse for another few seconds

Following the above steps, without the changes, I was able to cause a key stick around once in every three tries. With these changes I have not been able to get a key to stick.
