### PR TITLE
Typo 'occurred' in gui.ts

### DIFF
--- a/src/gui/gui.ts
+++ b/src/gui/gui.ts
@@ -1025,7 +1025,7 @@ Double click on a screen to edit its settings.</source>
     </message>
     <message>
         <location filename="src/SetupWizard.cpp" line="265"/>
-        <source>Sorry, an error occured while trying to sign in. Please contact the help desk, and provide the following details.
+        <source>Sorry, an error occurred while trying to sign in. Please contact the help desk, and provide the following details.
 
 %1</source>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
Corrected a small typo concerning an error message I received myself while using synergy.