### PR TITLE
Typo 'occurred' in WebClient.cpp

### DIFF
--- a/src/gui/src/WebClient.cpp
+++ b/src/gui/src/WebClient.cpp
@@ -41,7 +41,7 @@ int WebClient::getEdition(
 	{
 		message.critical(
 			w, "Error",
-			tr("An error occured while trying to sign in. "
+			tr("An error occurred while trying to sign in. "
 			"Please contact the helpdesk, and provide the "
 			"following details.\n\n%1").arg(e.what()));
 		return edition;


### PR DESCRIPTION
Corrected a small typo concerning an error message I received myself while using synergy.