### PR TITLE
Fix missing DLLs after install #3774

### DIFF
--- a/src/setup/win32/Product.wxs
+++ b/src/setup/win32/Product.wxs
@@ -110,13 +110,13 @@
           <fire:FirewallException Id="GuiFirewallException" Name="$(var.Name)" Scope="any" IgnoreFailure="yes" />
         </File>
 
-        <File Source="$(var.QtPath)\libgcc_s_dw2-1.dll" CompanionFile="GuiProgram" />
-        <File Source="$(var.QtPath)\mingwm10.dll" CompanionFile="GuiProgram" />
-        <File Source="$(var.QtPath)\QtCore4.dll" CompanionFile="GuiProgram" />
-        <File Source="$(var.QtPath)\QtGui4.dll" CompanionFile="GuiProgram" />
-        <File Source="$(var.QtPath)\QtNetwork4.dll" CompanionFile="GuiProgram" />
+        <File Source="$(var.QtPath)\libgcc_s_dw2-1.dll" />
+        <File Source="$(var.QtPath)\mingwm10.dll" />
+        <File Source="$(var.QtPath)\QtCore4.dll" />
+        <File Source="$(var.QtPath)\QtGui4.dll" />
+        <File Source="$(var.QtPath)\QtNetwork4.dll" />
         
-        <File Source="$(var.ExtPath)\bonjour\x64\dnssd.dll" CompanionFile="GuiProgram" />
+        <File Source="$(var.ExtPath)\bonjour\x64\dnssd.dll" />
 
       </Component>
       


### PR DESCRIPTION
The WiX `CompanionFile` attribute was causing the installer to be confused, logging:
``Won't Overwrite; Won't patch; Existing file is unversioned but modified``
and hence not installing a bunch of the DLLs in some cases.

Removing this attribute makes the installer work as expected again on a machine which previously reproduced #3774.

@nbolton @XinyuHou please review

P.S. this is my first PR to Synergy so please tell me if I'm doing anything wrong, or if I need to kick off a build etc...! :smiley: 