### PR TITLE
Fix issue synergy/synergy#4720

### DIFF
--- a/src/gui/src/PluginManager.cpp
+++ b/src/gui/src/PluginManager.cpp
@@ -194,13 +194,7 @@ QString PluginManager::getPluginUrl(const QString& pluginName)
 	process.start(program, args);
 	bool success = process.waitForStarted();
 
-	if (!success || !process.waitForFinished())
-	{
-		emit error(tr("Could not get Linux package type."));
-		return "";
-	}
-
-	bool isDeb = (process.exitCode() == 0);
+	bool isDeb = (success && process.waitForFinished() & (process.exitCode() == 0));
 
 	int arch = getProcessorArch();
 	if (arch == kProcessorArchLinux32) {


### PR DESCRIPTION
Fixes "Plugin download fails on CentOS with 'Could not get Linux package type' error" (see issue synergy/synergy#4720) according to @nbolton suggestion.

It has been succesfully built, packaged and tested with success on my centos 6.5 machine. It means that the ns plugin is now correctly downloaded on centos 6.5 and ssl encryption is available again.