### PR TITLE
Updated link on README and renamed to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ Just use "hm conf" and "hm build" to compile (./hm.sh on
 Linux and Mac).
 
 For detailed compile instructions:
-http://synergy-project.org/wiki/Compiling
+https://github.com/synergy/synergy/wiki/Compiling
 
 Happy hacking!


### PR DESCRIPTION
Former link for Compile Instructions was on Synergy wiki, which is being migrated to GitHub Wiki. Also I renamed the README file so it can be automatically loaded by GitHub as a Markdown document.