### PR TITLE
Fix Korean toggle key issue

### DIFF
--- a/src/lib/synergy/key_types.h
+++ b/src/lib/synergy/key_types.h
@@ -110,10 +110,12 @@ static const KeyID		kKeyScrollLock	= 0xEF14;
 static const KeyID		kKeySysReq		= 0xEF15;
 static const KeyID		kKeyEscape		= 0xEF1B;
 static const KeyID		kKeyHenkan		= 0xEF23;	/* Start/Stop Conversion */
-static const KeyID		kKeyHangulKana	= 0xEF26;	/* Hangul, Kana */
+static const KeyID		kKeyKana		= 0xEF26;	/* Kana */
 static const KeyID		kKeyHiraganaKatakana = 0xEF27;	/* Hiragana/Katakana toggle */
 static const KeyID		kKeyZenkaku		= 0xEF2A;	/* Zenkaku/Hankaku */
-static const KeyID		kKeyHanjaKanzi	= 0xEF2A;	/* Hanja, Kanzi */
+static const KeyID		kKeyKanzi		= 0xEF2A;	/* Kanzi */
+static const KeyID		kKeyHangul  	= 0xEF31;	/* Hangul */
+static const KeyID		kKeyHanja  		= 0xEF34;	/* Hanja */
 static const KeyID		kKeyDelete		= 0xEFFF;	/* Delete, rubout */
 
 // cursor control


### PR DESCRIPTION
Korean and Japanese keyboards have same keycode in widnows
(VK_HANGUL == VK_KANA and VK_HANJA == VK_KANJI)
But They have different X11 keysym.